### PR TITLE
improve/fix drag-drop multiple filetypes

### DIFF
--- a/Ahk2Exe.ahk
+++ b/Ahk2Exe.ahk
@@ -85,13 +85,21 @@ gosub SaveSettings
 ExitApp
 
 GuiDropFiles:
-if A_EventInfo > 2
-	Util_Error("You cannot drop more than one file into this window!")
-SplitPath, A_GuiEvent,,, dropExt
-if dropExt = ahk
-	GuiControl,, AhkFile, %A_GuiEvent%
-else if dropExt = ico
-	GuiControl,, IcoFile, %A_GuiEvent%
+if A_EventInfo > 3
+	Util_Error("You cannot drop more than one ahk, ico and exe file into this window!")
+else
+{
+	loop, parse, A_GuiEvent, `n
+	{
+		SplitPath, A_LoopField,,, dropExt
+		if dropExt = ahk
+			GuiControl,, AhkFile, %A_LoopField%
+		else if dropExt = exe
+			GuiControl,, ExeFile, %A_LoopField%
+		else if dropExt = ico
+			GuiControl,, IcoFile, %A_LoopField%
+	}
+}
 return
 
 AddPicture:

--- a/Ahk2Exe.ahk
+++ b/Ahk2Exe.ahk
@@ -92,12 +92,7 @@ else
 	loop, parse, A_GuiEvent, `n
 	{
 		SplitPath, A_LoopField,,, dropExt
-		if dropExt = ahk
-			GuiControl,, AhkFile, %A_LoopField%
-		else if dropExt = exe
-			GuiControl,, ExeFile, %A_LoopField%
-		else if dropExt = ico
-			GuiControl,, IcoFile, %A_LoopField%
+		GuiControl,, %dropExt%File, %A_LoopField%
 	}
 }
 return


### PR DESCRIPTION
Mainly fixed this bug:
![2016-08-23_22-46-02](https://cloud.githubusercontent.com/assets/3525376/17901040/7bbdee76-6983-11e6-9e76-9512973c2641.png)
all dropped files were being sent to the same field.

Also added detection of exe file drops.
