### PR TITLE
Add MPRESS command line options

### DIFF
--- a/Ahk2Exe.ahk
+++ b/Ahk2Exe.ahk
@@ -69,6 +69,8 @@ Gui, Add, Button, x519 y241 w53 h23 gDefaultIco, D&efault
 Gui, Add, Text, x18 y274, Base File (.bin)
 Gui, Add, DDL, x138 y270 w315 h23 R10 AltSubmit vBinFileId Choose%BinFileId%, %BinNames%
 Gui, Add, CheckBox, x138 y298 w315 h20 vUseMpress Checked%LastUseMPRESS%, Use MPRESS (if present) to compress resulting exe
+Gui, Add, Text, x461 y302, Parameters:
+Gui, Add, Edit, x521 y296 w53 h23 vMpressParams
 Gui, Add, Button, x258 y329 w75 h28 Default gConvert, > &Convert <
 Gui, Add, Statusbar,, Ready
 if !A_IsCompiled
@@ -258,7 +260,7 @@ CLIMode := true
 return
 
 BadParams:
-Util_Info("Command Line Parameters:`n`n" A_ScriptName " /in infile.ahk [/out outfile.exe] [/icon iconfile.ico] [/bin AutoHotkeySC.bin] [/mpress 1 (true) or 0 (false)] [/cp codepage]")
+Util_Info("Command Line Parameters:`n`n" A_ScriptName " /in infile.ahk [/out outfile.exe] [/icon iconfile.ico] [/bin AutoHotkeySC.bin] [/mpress 1 (true) or 0 (false) or ""<params>"" to pass to MPRESS] [/cp codepage]")
 ExitApp, 0x3
 
 _ProcessIn:
@@ -324,6 +326,8 @@ Convert:
 Gui, +OwnDialogs
 Gui, Submit, NoHide
 BinFile := A_ScriptDir "\" BinFiles[BinFileId]
+if UseMpress && MpressParams
+	UseMpress := MpressParams
 ConvertCLI:
 AhkCompile(AhkFile, ExeFile, IcoFile, BinFile, UseMpress, ScriptFileCP)
 if !CLIMode

--- a/Ahk2Exe.ahk
+++ b/Ahk2Exe.ahk
@@ -1,4 +1,4 @@
-;
+﻿;
 ; File encoding:  UTF-8
 ;
 ; Script description:
@@ -326,10 +326,8 @@ Convert:
 Gui, +OwnDialogs
 Gui, Submit, NoHide
 BinFile := A_ScriptDir "\" BinFiles[BinFileId]
-if UseMpress && MpressParams
-	UseMpress := MpressParams
 ConvertCLI:
-AhkCompile(AhkFile, ExeFile, IcoFile, BinFile, UseMpress, ScriptFileCP)
+AhkCompile(AhkFile, ExeFile, IcoFile, BinFile, UseMpress, MpressParams, ScriptFileCP)
 if !CLIMode
 	Util_Info("Conversion complete.")
 else
@@ -364,6 +362,7 @@ RegWrite, REG_SZ, HKCU, Software\AutoHotkey\Ahk2Exe, LastExeDir, %ExeFileDir%
 RegWrite, REG_SZ, HKCU, Software\AutoHotkey\Ahk2Exe, LastIconDir, %IcoFileDir%
 RegWrite, REG_SZ, HKCU, Software\AutoHotkey\Ahk2Exe, LastIcon, %IcoFile%
 RegWrite, REG_SZ, HKCU, Software\AutoHotkey\Ahk2Exe, LastUseMPRESS, %UseMPRESS%
+
 if !CustomBinFile
 	RegWrite, REG_SZ, HKCU, Software\AutoHotkey\Ahk2Exe, LastBinFile, % BinFiles[BinFileId]
 return

--- a/Ahk2Exe.ahk
+++ b/Ahk2Exe.ahk
@@ -1,4 +1,4 @@
-﻿;
+;
 ; File encoding:  UTF-8
 ;
 ; Script description:
@@ -68,8 +68,8 @@ Gui, Add, Button, x461 y241 w53 h23 gBrowseIco, Br&owse
 Gui, Add, Button, x519 y241 w53 h23 gDefaultIco, D&efault
 Gui, Add, Text, x18 y274, Base File (.bin)
 Gui, Add, DDL, x138 y270 w315 h23 R10 AltSubmit vBinFileId Choose%BinFileId%, %BinNames%
-Gui, Add, CheckBox, x138 y298 w315 h20 vUseMpress Checked%LastUseMPRESS%, Use MPRESS (if present) to compress resulting exe
-Gui, Add, Text, x461 y302, Parameters:
+Gui, Add, CheckBox, x138 y298 w270 h20 vUseMpress Checked%LastUseMPRESS%, Use MPRESS (if present) to compress resulting exe
+Gui, Add, Text, x412 y302, MPRESS Parameters
 Gui, Add, Edit, x521 y296 w53 h23 vMpressParams
 Gui, Add, Button, x258 y329 w75 h28 Default gConvert, > &Convert <
 Gui, Add, Statusbar,, Ready

--- a/Ahk2Exe.ahk
+++ b/Ahk2Exe.ahk
@@ -68,9 +68,9 @@ Gui, Add, Button, x461 y241 w53 h23 gBrowseIco, Br&owse
 Gui, Add, Button, x519 y241 w53 h23 gDefaultIco, D&efault
 Gui, Add, Text, x18 y274, Base File (.bin)
 Gui, Add, DDL, x138 y270 w315 h23 R10 AltSubmit vBinFileId Choose%BinFileId%, %BinNames%
-Gui, Add, CheckBox, x138 y298 w270 h20 vUseMpress Checked%LastUseMPRESS%, Use MPRESS (if present) to compress resulting exe
+Gui, Add, CheckBox, x138 y298 w270 h20 vUseMPRESS Checked%LastUseMPRESS%, Use MPRESS (if present) to compress resulting exe
 Gui, Add, Text, x412 y302, MPRESS Parameters
-Gui, Add, Edit, x521 y296 w53 h23 vMpressParams
+Gui, Add, Edit, x521 y296 w53 h23 vMPRESSparams, %LastMPRESSparams%
 Gui, Add, Button, x258 y329 w75 h28 Default gConvert, > &Convert <
 Gui, Add, Statusbar,, Ready
 if !A_IsCompiled
@@ -327,7 +327,7 @@ Gui, +OwnDialogs
 Gui, Submit, NoHide
 BinFile := A_ScriptDir "\" BinFiles[BinFileId]
 ConvertCLI:
-AhkCompile(AhkFile, ExeFile, IcoFile, BinFile, UseMpress, MpressParams, ScriptFileCP)
+AhkCompile(AhkFile, ExeFile, IcoFile, BinFile, UseMPRESS, MPRESSparams, ScriptFileCP)
 if !CLIMode
 	Util_Info("Conversion complete.")
 else
@@ -341,6 +341,7 @@ RegRead, LastIconDir, HKCU, Software\AutoHotkey\Ahk2Exe, LastIconDir
 RegRead, LastIcon, HKCU, Software\AutoHotkey\Ahk2Exe, LastIcon
 RegRead, LastBinFile, HKCU, Software\AutoHotkey\Ahk2Exe, LastBinFile
 RegRead, LastUseMPRESS, HKCU, Software\AutoHotkey\Ahk2Exe, LastUseMPRESS
+RegRead, LastMPRESSparams, HKCU, Software\AutoHotkey\Ahk2Exe, LastMPRESSparams
 if LastBinFile =
 	LastBinFile = AutoHotkeySC.bin
 if LastUseMPRESS
@@ -362,7 +363,7 @@ RegWrite, REG_SZ, HKCU, Software\AutoHotkey\Ahk2Exe, LastExeDir, %ExeFileDir%
 RegWrite, REG_SZ, HKCU, Software\AutoHotkey\Ahk2Exe, LastIconDir, %IcoFileDir%
 RegWrite, REG_SZ, HKCU, Software\AutoHotkey\Ahk2Exe, LastIcon, %IcoFile%
 RegWrite, REG_SZ, HKCU, Software\AutoHotkey\Ahk2Exe, LastUseMPRESS, %UseMPRESS%
-
+RegWrite, REG_SZ, HKCU, Software\AutoHotkey\Ahk2Exe, LastMPRESSparams, %MPRESSparams%
 if !CustomBinFile
 	RegWrite, REG_SZ, HKCU, Software\AutoHotkey\Ahk2Exe, LastBinFile, % BinFiles[BinFileId]
 return

--- a/Ahk2Exe.ahk
+++ b/Ahk2Exe.ahk
@@ -282,7 +282,7 @@ return
 
 _ProcessMPRESS:
 UseMPRESS := p2
-if p2 && p2 <> 1
+if p2 && p2 != 1
 	MPRESSparams := p2
 return
 

--- a/Ahk2Exe.ahk
+++ b/Ahk2Exe.ahk
@@ -282,6 +282,8 @@ return
 
 _ProcessMPRESS:
 UseMPRESS := p2
+if p2 && p2 <> 1
+	MPRESSparams := p2
 return
 
 _ProcessCP: ; for example: '/cp 1252' or '/cp UTF-8'

--- a/Compiler.ahk
+++ b/Compiler.ahk
@@ -1,7 +1,7 @@
 #Include ScriptParser.ahk
 #Include IconChanger.ahk
 
-AhkCompile(ByRef AhkFile, ExeFile="", ByRef CustomIcon="", BinFile="", UseMPRESS="", fileCP="")
+AhkCompile(ByRef AhkFile, ExeFile="", ByRef CustomIcon="", BinFile="", UseMPRESS="", MPRESSparams="", fileCP="")
 {
 	global ExeFileTmp
 	AhkFile := Util_GetFullPath(AhkFile)
@@ -34,8 +34,6 @@ AhkCompile(ByRef AhkFile, ExeFile="", ByRef CustomIcon="", BinFile="", UseMPRESS
 	if FileExist(A_ScriptDir "\mpress.exe") && UseMPRESS
 	{
 		Util_Status("Compressing final executable...")
-		if UseMPRESS <> 1 
-			MPRESSparams := UseMPRESS
 		RunWait, "%A_ScriptDir%\mpress.exe" %MPRESSparams% -q -x "%ExeFileTmp%",, Hide
 	}
 	

--- a/Compiler.ahk
+++ b/Compiler.ahk
@@ -33,7 +33,6 @@ AhkCompile(ByRef AhkFile, ExeFile="", ByRef CustomIcon="", BinFile="", UseMPRESS
 	
 	if FileExist(A_ScriptDir "\mpress.exe") && UseMPRESS
 	{
-		Util_Status("Compressing final executable...")
 		if UseMPRESS <> 1 
 			MPRESSparams := UseMPRESS
 		RunWait, "%A_ScriptDir%\mpress.exe" %MPRESSparams% -q -x "%ExeFileTmp%",, Hide

--- a/Compiler.ahk
+++ b/Compiler.ahk
@@ -33,6 +33,7 @@ AhkCompile(ByRef AhkFile, ExeFile="", ByRef CustomIcon="", BinFile="", UseMPRESS
 	
 	if FileExist(A_ScriptDir "\mpress.exe") && UseMPRESS
 	{
+		Util_Status("Compressing final executable...")
 		if UseMPRESS <> 1 
 			MPRESSparams := UseMPRESS
 		RunWait, "%A_ScriptDir%\mpress.exe" %MPRESSparams% -q -x "%ExeFileTmp%",, Hide

--- a/Compiler.ahk
+++ b/Compiler.ahk
@@ -34,7 +34,9 @@ AhkCompile(ByRef AhkFile, ExeFile="", ByRef CustomIcon="", BinFile="", UseMPRESS
 	if FileExist(A_ScriptDir "\mpress.exe") && UseMPRESS
 	{
 		Util_Status("Compressing final executable...")
-		RunWait, "%A_ScriptDir%\mpress.exe" -q -x "%ExeFileTmp%",, Hide
+		if UseMPRESS <> 1 
+			MPRESSparams := UseMPRESS
+		RunWait, "%A_ScriptDir%\mpress.exe" %MPRESSparams% -q -x "%ExeFileTmp%",, Hide
 	}
 	
 	; the final step...


### PR DESCRIPTION
This adds the ability to specify command line options to MPRESS, both in the GUI and on the command line. I also modified the help text, and save the last used GUI option to the registry.