### PR TITLE
Add /silent, /verbose and /ForceReload

### DIFF
--- a/Ahk2Exe.ahk
+++ b/Ahk2Exe.ahk
@@ -1,4 +1,4 @@
-; 
+﻿; 
 ; File encoding:  UTF-8 with BOM
 ;
 ; Script description:
@@ -702,9 +702,10 @@ Util_Error(txt, exitcode, extra := "", extra1 := "")
 	Util_Status("Ready")
 	
 	if exitcode
-		if !Error_ForceExit
-			Exit, exitcode
-		else ExitApp, exitcode
+		if Error_ForceExit || SilentMode
+			ExitApp, %exitcode%
+		else
+			Exit, %exitcode% 
 	Util_DisplayHourglass()
 }
 

--- a/Ahk2Exe.ahk
+++ b/Ahk2Exe.ahk
@@ -1,4 +1,4 @@
-; 
+﻿; 
 ; File encoding:  UTF-8 with BOM
 ;
 ; Script description:
@@ -575,11 +575,11 @@ for k, v1 in StopCDBin ? [] : DirBinsWk
 }	}
 if Util_ObjNotEmpty(DirBins)
 	for k in DirBins
-		 AhkCompile(AhkFile, DirExe[k], IcoFile, DirBins[k],UseMpress
+		 ExeFile:= AhkCompile(AhkFile, DirExe[k], IcoFile, DirBins[k],UseMpress
 		                                       , DirCP[k] ? DirCP[k] : ScriptFileCP)
-else AhkCompile(AhkFile, ExeFile,   IcoFile, BinFile,   UseMpress, ScriptFileCP)
+else ExeFile:= AhkCompile(AhkFile, ExeFile,   IcoFile, BinFile,   UseMpress, ScriptFileCP)
 
-	Util_Info("Conversion complete.")
+Util_Info("Conversion complete.")
 if CLIMode
 	FileAppend, Successfully compiled: %ExeFile%`n, *
 return
@@ -684,14 +684,14 @@ Util_Error(txt, exitcode, extra := "", extra1 := "")
 	if HeadlessMode {
 		FileAppend, % "Ahk2Exe " (exitcode? "Error" : "Warning") ": " txt "`n", *
 	} else {
-	if exitcode
-		MsgBox, 16, Ahk2Exe Error, % txt
-	else {
-		MsgBox, 49, Ahk2Exe Warning, % txt
-	. (extra||extra1 ? "" : "`n`nPress 'OK' to continue, or 'Cancel' to abandon.")
-		IfMsgBox Cancel
-			exitcode := 2
-	}
+		if exitcode
+			MsgBox, 16, Ahk2Exe Error, % txt
+		else {
+			MsgBox, 49, Ahk2Exe Warning, % txt
+		. (extra||extra1 ? "" : "`n`nPress 'OK' to continue, or 'Cancel' to abandon.")
+			IfMsgBox Cancel
+				exitcode := 2
+		}
 	}
 	if (exitcode && ExeFileTmp && FileExist(ExeFileTmp))
 	{	FileDelete, %ExeFileTmp%

--- a/Ahk2Exe.ahk
+++ b/Ahk2Exe.ahk
@@ -1,4 +1,4 @@
-; 
+﻿; 
 ; File encoding:  UTF-8 with BOM
 ;
 ; Script description:
@@ -671,7 +671,7 @@ Util_Status(s)
 		if s not in ,Ready
 			FileAppend, Ahk2Exe Status: %s%`n, *
 	} 
-		SB_SetText(s)
+	SB_SetText(s)
 }
 
 Util_Error(txt, exitcode, extra := "", extra1 := "")
@@ -717,7 +717,7 @@ Util_Error(txt, exitcode, extra := "", extra1 := "")
 Util_Info(txt)
 {	
 	global
-	if SilentMode
+	if CLIMode
 		FileAppend, Ahk2Exe Info: %txt%`n, *
 	else
 		MsgBox, 64, Ahk2Exe, % txt

--- a/Ahk2Exe.ahk
+++ b/Ahk2Exe.ahk
@@ -352,17 +352,17 @@ BadParams(Message, ErrorCode=0x3)
 	(LTrim
 	Command Line Parameters:
 	Ahk2Exe.exe
-	`t[/silent]
-	`t[/gui]
-	`t /in infile.ahk
-	`t[/out outfile.exe]
-	`t[/icon iconfile.ico]
-	`t[/bin AutoHotkeySC.bin]
-	`t[/compress 0 (none), 1 (MPRESS), or 2 (UPX)]
-	`t[/cp codepage]
-	`t[/ahk path\name]
-	`t[/ForceReload]
-	`t[/verbose]
+	`t[/silent]	          Disable MsgBoxes and instead output errors/info to stderr/stdout
+	`t[/gui]                    Show the GUI instead of immediately compiling
+	`t /in infile.ahk           The path and name of the script to compile
+	`t[/out outfile.exe]        The path/name of the output .exe to be created
+	`t[/icon iconfile.ico]      The icon file to be used
+	`t[/bin AutoHotkeySC.bin]   The .bin file to be used
+	`t[/compress number]        Compress the .exe, number can be 0 (no compression), 1 (MPRESS) or 2 (UPX)
+	`t[/cp codepage]            Overrides the default codepage used to read script files
+	`t[/ahk path\name]          The path\name of AutoHotkey.exe to be used when compiling the script
+	`t[/ForceReload]            Force the script to be reloaded if it's running
+	`t[/verbose]                Output the compiler status to stdout
 	)
 	Util_Error(Message, ErrorCode,, params)
 }

--- a/Ahk2Exe.ahk
+++ b/Ahk2Exe.ahk
@@ -352,17 +352,17 @@ BadParams(Message, ErrorCode=0x3)
 	(LTrim
 	Command Line Parameters:
 	Ahk2Exe.exe
-	`t[/silent]	          Disable MsgBoxes and instead output errors/info to stderr/stdout
-	`t[/gui]                    Show the GUI instead of immediately compiling
-	`t /in infile.ahk           The path and name of the script to compile
-	`t[/out outfile.exe]        The path/name of the output .exe to be created
-	`t[/icon iconfile.ico]      The icon file to be used
-	`t[/bin AutoHotkeySC.bin]   The .bin file to be used
-	`t[/compress number]        Compress the .exe, number can be 0 (no compression), 1 (MPRESS) or 2 (UPX)
-	`t[/cp codepage]            Overrides the default codepage used to read script files
-	`t[/ahk path\name]          The path\name of AutoHotkey.exe to be used when compiling the script
-	`t[/ForceReload]            Force the script to be reloaded if it's running
-	`t[/verbose]                Output the compiler status to stdout
+	`t[/silent]
+	`t[/gui]
+	`t /in infile.ahk
+	`t[/out outfile.exe]
+	`t[/icon iconfile.ico]
+	`t[/bin AutoHotkeySC.bin]
+	`t[/compress 0 (none), 1 (MPRESS), or 2 (UPX)]
+	`t[/cp codepage]
+	`t[/ahk path\name]
+	`t[/ForceReload]
+	`t[/verbose]
 	)
 	Util_Error(Message, ErrorCode,, params)
 }

--- a/Ahk2Exe.ahk
+++ b/Ahk2Exe.ahk
@@ -322,19 +322,21 @@ while p.MaxIndex()
 	p1 := p.RemoveAt(1)
 	
 	if SubStr(p1,1,1) != "/" || !(p1fn := Func("CmdArg_" SubStr(p1,2)))
-		BadParams("Error: Unrecognised parameter:`n" p1)
+		BadParams("Unrecognised parameter:`n" p1)
 	
 	if p1fn.MaxParams  ; Currently assumes 0 or 1 params.
 	{
 		p2 := p.RemoveAt(1)
 		if p2 =
-			BadParams("Error: Blank or missing parameter for " p1 ".")
+			BadParams("Blank or missing parameter for " p1 ".")
 	}
 	
 	%p1fn%(p2)
 }
 
 if (AhkFile = "" && CLIMode)
+	BadParams("No input file specified.")
+
 if (HeadlessMode && !CLIMode){
 	BadParams("Headless mode requires CLI mode.")
 	ExitApp, 0x3
@@ -394,7 +396,7 @@ CmdArg_MPRESS(p2) {
 CmdArg_Compress(p2) {
 	global
 	if !CompressCode[p2]                ; Invalid codes?
-		BadParams("Error: " p1 " parameter invalid:`n" p2)
+		BadParams(p1 " parameter invalid:`n" p2)
 	if CompressCode[p2] > 0             ; Convert any old codes
 		p2 := CompressCode[p2]
 	UseMPRESS := p2
@@ -425,11 +427,11 @@ CmdArg_ForceReload(){
 }
 
 CmdArg_Pass() {
-	BadParams("Error: Password protection is not supported.", 0x24)
+	BadParams("Password protection is not supported.", 0x24)
 }
 
 CmdArg_NoDecompile() {
-	BadParams("Error: /NoDecompile is not supported.", 0x23)
+	BadParams("/NoDecompile is not supported.", 0x23)
 }
 
 BrowseAhk:

--- a/Ahk2Exe.ahk
+++ b/Ahk2Exe.ahk
@@ -1,4 +1,4 @@
-﻿; 
+; 
 ; File encoding:  UTF-8 with BOM
 ;
 ; Script description:
@@ -316,6 +316,7 @@ Loop, %0%
 CLIMode := true  
 SilentMode := false
 ForceReload := false
+Verbose := false
 
 while p.MaxIndex()
 {
@@ -361,6 +362,7 @@ BadParams(Message, ErrorCode=0x3)
 	`t[/cp codepage]
 	`t[/ahk path\name]
 	`t[/ForceReload]
+	`t[/verbose]
 	)
 	Util_Error(Message, ErrorCode,, params)
 }
@@ -423,6 +425,10 @@ CmdArg_Silent(){
 
 CmdArg_ForceReload(){
 	global ForceReload:= true
+}
+
+CmdArg_Verbose(){
+	global Verbose:= true
 }
 
 CmdArg_Pass() {
@@ -661,12 +667,11 @@ return
 Util_Status(s)
 {
 	global
-	if SilentMode{
+	if Verbose{
 		if s not in ,Ready
 			FileAppend, Ahk2Exe Status: %s%`n, *
-	}else 
+	} 
 		SB_SetText(s)
-
 }
 
 Util_Error(txt, exitcode, extra := "", extra1 := "")

--- a/Ahk2Exe.ahk
+++ b/Ahk2Exe.ahk
@@ -1,4 +1,4 @@
-﻿; 
+; 
 ; File encoding:  UTF-8 with BOM
 ;
 ; Script description:
@@ -314,7 +314,7 @@ Loop, %0%
 
 ; Set defaults - may be overridden.
 CLIMode := true  
-HeadlessMode := false
+SilentMode := false
 ForceReload := false
 
 while p.MaxIndex()
@@ -337,9 +337,8 @@ while p.MaxIndex()
 if (AhkFile = "" && CLIMode)
 	BadParams("No input file specified.")
 
-if (HeadlessMode && !CLIMode){
-	BadParams("Headless mode requires CLI mode.")
-	ExitApp, 0x3
+if (SilentMode && !CLIMode){
+	BadParams("/silent requires CLI mode.")
 }
 
 if BinFile =
@@ -352,7 +351,7 @@ BadParams(Message, ErrorCode=0x3)
 	(LTrim
 	Command Line Parameters:
 	Ahk2Exe.exe
-	`t[/headless]
+	`t[/silent]
 	`t[/gui]
 	`t /in infile.ahk
 	`t[/out outfile.exe]
@@ -418,8 +417,8 @@ CmdArg_CP(p2) { ; for example: '/cp 1252' or '/cp UTF-8'
 		ScriptFileCP := p2
 }
 
-CmdArg_Headless(){
-	global HeadlessMode:= true
+CmdArg_Silent(){
+	global SilentMode:= true
 }
 
 CmdArg_ForceReload(){
@@ -662,7 +661,7 @@ return
 Util_Status(s)
 {
 	global
-	if HeadlessMode{
+	if SilentMode{
 		if s not in ,Ready
 			FileAppend, Ahk2Exe Status: %s%`n, *
 	}else 
@@ -672,7 +671,7 @@ Util_Status(s)
 
 Util_Error(txt, exitcode, extra := "", extra1 := "")
 {
-	global CLIMode, Error_ForceExit, ExeFileTmp, HeadlessMode
+	global CLIMode, Error_ForceExit, ExeFileTmp, SilentMode
 	
 	if extra
 		txt .= "`n`nSpecifically:`n" extra
@@ -681,8 +680,8 @@ Util_Error(txt, exitcode, extra := "", extra1 := "")
 		txt .= "`n`n" extra1
 	
 	Util_HideHourglass()
-	if HeadlessMode {
-		FileAppend, % "Ahk2Exe " (exitcode? "Error" : "Warning") ": " txt "`n", *
+	if CLIMode && SilentMode {
+		FileAppend, % "Ahk2Exe " (exitcode? "Error" : "Warning") ": " txt "`n", **
 	} else {
 		if exitcode
 			MsgBox, 16, Ahk2Exe Error, % txt
@@ -699,7 +698,7 @@ Util_Error(txt, exitcode, extra := "", extra1 := "")
 	}
 
 	if CLIMode && exitcode
-		FileAppend, Failed to compile: %ExeFile%`n, *
+		FileAppend, Failed to compile: %ExeFile%`n, **
 	Util_Status("Ready")
 	
 	if exitcode
@@ -712,7 +711,7 @@ Util_Error(txt, exitcode, extra := "", extra1 := "")
 Util_Info(txt)
 {	
 	global
-	if HeadlessMode
+	if SilentMode
 		FileAppend, Ahk2Exe Info: %txt%`n, *
 	else
 		MsgBox, 64, Ahk2Exe, % txt

--- a/Compiler.ahk
+++ b/Compiler.ahk
@@ -1,4 +1,4 @@
-;
+﻿;
 ; File encoding:  UTF-8 with BOM
 ;
 #Include ScriptParser.ahk
@@ -86,24 +86,24 @@ AhkCompile(ByRef AhkFile, ExeFile="", ByRef CustomIcon="", BinFile="", UseMPRESS
 				Process, Close, %ExePid%
 				Process, WaitClose, %ExePid%, 1
 			}else {
-			wk := """" RegExReplace(ExeFileG, "^.+\\") """"
+				wk := """" RegExReplace(ExeFileG, "^.+\\") """"
 				if HeadlessMode {
 					Util_Error(wk " is still running, "
 					.  "and needs to be unloaded to allow replacement with this new version."
 					. "`nPass /ForceReload to always reload when compiling.", 0x45)
 				} else {
 					SetTimer Buttons, 50
-			MsgBox 51,Ahk2Exe Query,% "Warning: " wk " is still running, "
-			.  "and needs to be unloaded to allow replacement with this new version."
-			. "`n`n Press the appropriate button to continue."
-			. " ('Reload' unloads and reloads the new " wk " without any parameters.)"
-			IfMsgBox Cancel
-				Util_Error("Error: Could not move final compiled binary file to "
-				. "destination. (C2)", 0x45, """" ExeFileG """")
-			WinClose     ahk_exe %ExeFileG%
-			WinWaitClose ahk_exe %ExeFileG%,,1
-			IfMsgBox No
-				Reload := 1
+					MsgBox 51,Ahk2Exe Query,% "Warning: " wk " is still running, "
+					.  "and needs to be unloaded to allow replacement with this new version."
+					. "`n`n Press the appropriate button to continue."
+					. " ('Reload' unloads and reloads the new " wk " without any parameters.)"
+					IfMsgBox Cancel
+						Util_Error("Error: Could not move final compiled binary file to "
+						. "destination. (C2)", 0x45, """" ExeFileG """")
+					WinClose     ahk_exe %ExeFileG%
+					WinWaitClose ahk_exe %ExeFileG%,,1
+					IfMsgBox No
+						Reload := 1
 				}
 			}
 		}	
@@ -112,6 +112,7 @@ AhkCompile(ByRef AhkFile, ExeFile="", ByRef CustomIcon="", BinFile="", UseMPRESS
 		Run "%ExeFileG%", %ExeFileG%\..
 	Util_HideHourglass()
 	Util_Status("")
+	Return ExeFileG
 }
 
 Buttons()

--- a/Compiler.ahk
+++ b/Compiler.ahk
@@ -7,7 +7,7 @@
 
 AhkCompile(ByRef AhkFile, ExeFile="", ByRef CustomIcon="", BinFile="", UseMPRESS="", fileCP="")
 {
-	global ExeFileTmp, ExeFileG, HeadlessMode, ForceReload
+	global ExeFileTmp, ExeFileG, SilentMode, ForceReload
 
 	SetWorkingDir %AhkWorkingDir%
 	SplitPath AhkFile,, Ahk_Dir,, Ahk_Name
@@ -87,7 +87,7 @@ AhkCompile(ByRef AhkFile, ExeFile="", ByRef CustomIcon="", BinFile="", UseMPRESS
 				Process, WaitClose, %ExePid%, 1
 			}else {
 				wk := """" RegExReplace(ExeFileG, "^.+\\") """"
-				if HeadlessMode {
+				if SilentMode {
 					Util_Error(wk " is still running, "
 					.  "and needs to be unloaded to allow replacement with this new version."
 					. "`nPass /ForceReload to always reload when compiling.", 0x45)


### PR DESCRIPTION
The commits do the following:
* Add `/silent` which disables the MsgBoxes and instead outputs `Util_Error` to stderr and `Util_Info` to stdout.
* Add `/ForceReload` which forces the script to reload if it's running, it uses `Process Close` instead of `WinClose`.
* Add `/verbose` to output `Util_Status` to stdout.
* Remove `Error: ` from the error string in all `BadParams()` calls, since the title of the MsgBox already says `Ahk2Exe Error` as does the stdout string.
* Make the `AhkCompile()` function return the path and name of the compiled .exe, this fixes the blank `ExeFile` variable when `/out` is not used.

I have checked the "Allow edits by maintainers" box, so you can modify the changes however you see fit.