### PR TITLE
Experimental AutoHotkey v2 Store Edition compatibility

### DIFF
--- a/Directives.ahk
+++ b/Directives.ahk
@@ -86,7 +86,7 @@ Directive_Obey(state, name, txt, extra:=0)
 			FileAppend % "`nFileOpen(""" wk A_Index
 			. """,""W"",""UTF-8"").Write(" name A_Index ")", %wk%, UTF-8
 		if SilentMode
-		{ RunWait,"%comspec%" /c ""%AhkPath%" %AhkSw% /ErrorStdOut "%wk%" 2>"%wk%E"",, UseErrorLevel Hide ; Editor may flag, but it's valid syntax
+		{ ErrorData := RunCMD("""%AhkPath%"" %AhkSw% /ErrorStdOut ""%wk%""") ; Editor may flag, but it's valid syntax
 			if ErrorLevel
 			{	FileRead ErrorData, %wk%E
 				FileDelete %wk%*

--- a/ScriptParser.ahk
+++ b/ScriptParser.ahk
@@ -185,6 +185,7 @@ PreprocessScript(ByRef ScriptText, AhkScript, Directives, PriorLines
 			}
 			PreprocessScript(ScriptText, ilibfile, Directives
 			, PriorLines, FileList, FirstScriptDir, Options)
+			FileDelete, %ilibfile%*
 		}
 		StringTrimRight, ScriptText, ScriptText, 1 ; remove trailing newline
 	}

--- a/Update.ahk
+++ b/Update.ahk
@@ -84,6 +84,12 @@ Gui Submit, NoHide
 GuiControl % Text1||Text2||Text3||Text4 ? "Upd:Enable" : "Upd:Disable", upd
 return
 
+UpdDirRem()
+{	global
+	If InStr(FileExist(UpdDir), "D")
+		FileRemoveDir %UpdDir%, 1
+}
+
 GetCsv(A2D, Req, UpdDir, Version, Store)
 {	If FileExist(A2D "..\UX\installed-files.csv") && !Store
 	{ path := """Compiler\" Req """"

--- a/Update.ahk
+++ b/Update.ahk
@@ -6,7 +6,7 @@ Reqs:=[(wk:="AutoHotkey/Ahk2Exe") ",,,Ahk2Exe.exe"
 A2D := A_ScriptDir "\", Store := A2D~="i)^.:\\Program Files\\WindowsApps\\"
 if !A_IsCompiled                               ; Compile Ahk2Exe to test updates
 	RunCMD("""" A_AhkPath  """ """ A_ScriptFullPath """ /compress 0 /in """ A_ScriptFullPath """ /base """ A_AhkPath "\..\AutoHotkeyU32.exe""", A_WorkingDir)
-UpdDirRem(), UpdDir := Util_TempFile(,"Update", "Update")
+UpdGui:=1, Priv:="", UpdDirRem(), UpdDir := Util_TempFile(,"Update", "Update")
 FileCreateDir %UpdDir%
 Gui Upd:Destroy
 ;Gui Upd:Font, s9, simsun                      ; To test overlapping GUI fields
@@ -84,14 +84,8 @@ Gui Submit, NoHide
 GuiControl % Text1||Text2||Text3||Text4 ? "Upd:Enable" : "Upd:Disable", upd
 return
 
-UpdDirRem()
-{	global
-	If InStr(FileExist(UpdDir), "D")
-		FileRemoveDir %UpdDir%, 1
-}
-
-GetCsv(A2D, Req, UpdDir, Version, Store)
-{	If FileExist(A2D "..\UX\installed-files.csv") && !Store
+GetCsv(A2D, Req, UpdDir, Version)
+{ IfExist %A2D%..\UX\installed-files.csv
 	{ path := """Compiler\" Req """"
 		if (Version != "Delete")
 		{	FileReadLine wk, %A2D%\..\UX\installed-files.csv, 1
@@ -134,9 +128,9 @@ for k, v in Reqs
 }
 if txt
 	Util_Error("Are you sure you want to delete:" txt, 0,,, 0)
-
 FileCreateDir %UpdDir%\A\
 FileCopy %A2D%Ahk2Exe.exe, %UpdDir%\A\Ahk2Exe.exe
+OnExit("UpdDirRem", 0)
 For k, v in A_Args            ; Add quotes to parameters & escape any trailing \
 	wk := StrReplace(v,"""","\"""), Par .= """" wk (SubStr(wk,0)="\"?"\":"") """ "
 
@@ -173,7 +167,7 @@ if txt`n	MsgBox 48, Ahk2Exe Updater, Failed to update:`%txt`%``n`%Mess`%
 else MsgBox 64, Ahk2Exe Updater, Update completed successfully. `%Mess`%
 IfExist %A2D%Ahk2Exe.exe
 {
-	if InStr("%A2D%", "\WindowsApps\")
+	if (Store)
 		Run, "%A2D%Ahk2Exe.exe" /Restart `%Par`%
 	else
 		RunAsUser("%A2D%Ahk2Exe.exe", "/Restart " Par, A_WorkingDir)
@@ -229,6 +223,12 @@ GitHubDwnldUrl(Repo, Ext := ".zip", Typ := 1)
 			if (!Ext || SubStr(url, 1-StrLen(Ext)) = Ext)
 				return Url
 }	}	}
+
+UpdDirRem()
+{	global
+	If InStr(FileExist(UpdDir), "D")
+		FileRemoveDir %UpdDir%, 1
+}
 
 RunCMD(CmdLine, WorkingDir:="", Codepage:="CP0", Fn:="RunCMD_Output", Slow:=1) { ; RunCMD v0.97
     Local         ; RunCMD v0.97 by SKAN on D34E/D67E @ autohotkey.com/boards/viewtopic.php?t=74647

--- a/Update.ahk
+++ b/Update.ahk
@@ -139,8 +139,8 @@ Script1Addon =
 `nPar = %Par%`nwk := []
 Loop Files, %UpdDir%\*.exe
 	txt .= "``n``t" A_LoopFileName, fail .= (fail ? "|" : "") A_LoopFileName
-IfExist `%Src`%\Script3c.csv
-{	Loop Read, `%Tgt`%..\UX\installed-files.csv
+IfExist `%UpdDir`%\Script3c.csv
+{	Loop Read, `%A2D`%..\UX\installed-files.csv
 	{	if (A_Index = 1)
 		{	hdr := A_LoopReadLine
 			for k, v in StrSplit(Hdr,",")
@@ -148,18 +148,18 @@ IfExist `%Src`%\Script3c.csv
 					break
 		}	else wk[StrSplit(A_LoopReadLine,",")[k]] := A_LoopReadLine
 	}
-	Loop Read, `%Src`%\Script3c.csv
+	Loop Read, `%UpdDir`%\Script3c.csv
 		if !(fail && A_LoopReadLine ~= "i)(" StrReplace(fail,".","\.") ")""")
 			if StrSplit(A_LoopReadLine,"|").2 = "Delete"
 				wk.Delete(StrSplit(A_LoopReadLine,"|").1)
 			else wk[StrSplit(A_LoopReadLine,"|").1] := StrSplit(A_LoopReadLine,"|").2
-	FileDelete             `%Tgt`%..\UX\installed-files.csv
-	FileAppend `%hdr`%``n, `%Tgt`%..\UX\installed-files.csv
+	FileDelete             `%A2D`%..\UX\installed-files.csv
+	FileAppend `%hdr`%``n, `%A2D`%..\UX\installed-files.csv
 	for k, v in wk
-		FileAppend `%v`%``n, `%Tgt`%..\UX\installed-files.csv
+		FileAppend `%v`%``n, `%A2D`%..\UX\installed-files.csv
 }
 ToolTip
-IfNotExist `%Tgt`%Ahk2Exe.exe
+IfNotExist `%A2D`%Ahk2Exe.exe
 	Mess:="``n``nAhk2Exe deleted. To reinstall:``n``n v1 - Run the AHK installer."
 . "``n v2 - Press 'Windows/Start', find & run AutoHotkey Dash => Compile.``n"
 . " MS Store version - Settings => Apps => AutoHotkey v2 => Advanced => Reset."


### PR DESCRIPTION
Hey,
I did some experiments and I found that RunCMD seems to support Store edition the best: it preserves file system virtualization and also supports getting input/output from the run script. This means that all instances of `RunWait,"%comspec%"` can be replaced with `RunCMD` without seemingly any downsides, and perhaps some speed improvement upsides (no need for file writes). This version also supports running and updating Ahk2Exe in S-mode, although the updated executables can't be run due to higher security demands.
This pull request isn't meant to be accepted straight away without modifications, rather perhaps you'd take a look at it and see whether it could be an option. I'll send you an updated Store edition privately.