### PR TITLE
Replace RunWait %ComSpec% with RunCMD

### DIFF
--- a/Directives.ahk
+++ b/Directives.ahk
@@ -86,10 +86,9 @@ Directive_Obey(state, name, txt, extra:=0)
 			FileAppend % "`nFileOpen(""" wk A_Index
 			. """,""W"",""UTF-8"").Write(" name A_Index ")", %wk%, UTF-8
 		if SilentMode
-		{ RunWait,"%comspec%" /c ""%AhkPath%" %AhkSw% /ErrorStdOut "%wk%" 2>"%wk%E"",, UseErrorLevel Hide ; Editor may flag, but it's valid syntax
-			if ErrorLevel
-			{	FileRead ErrorData, %wk%E
-				FileDelete %wk%*
+		{ ErrorData := RunCMD("""%AhkPath%"" %AhkSw% /ErrorStdOut ""%wk%""") ; Editor may flag, but it's valid syntax
+			if ErrorData
+			{	FileDelete %wk%*
 				Util_Error("Error: 'Obey' directive cannot be executed.",0x68,ErrorData)
 		}	} else RunWait "%AhkPath%" %AhkSw% "%wk%",,Hide
 		Loop % extra + 1

--- a/ScriptParser.ahk
+++ b/ScriptParser.ahk
@@ -166,25 +166,17 @@ PreprocessScript(ByRef ScriptText, AhkScript, Directives, PriorLines
 		AhkSw := wk ? " /Script " : " "
 		
 		ilibfile := Util_TempFile(, "ilib~")
-		RunWait,"%comspec%" /c ""%AhkPath%"%AhkSw%/iLib "%ilibfile%" /ErrorStdOut "%AhkScript%" 2>"%ilibfile%E"", %FirstScriptDir%, UseErrorLevel Hide
-		if ErrorLevel in 1, 2          ;^ Editor may flag, but it's valid syntax
-		{	FileDelete %ilibfile%        ; Avoid UNC path bug & allow MS Store compile
-			RunWait, "%AhkPath%" %AhkSw% /iLib "%ilibfile%" /ErrorStdOut "%AhkScript%" 2>"%ilibfile%A", %FirstScriptDir%, UseErrorLevel Hide
-		} ;^^ Bug ref https://www.autohotkey.com/boards/viewtopic.php?f=14&t=90457
+		tmpErrorData := RunCMD("""" AhkPath """" AhkSw "/iLib * /ErrorStdOut """ AhkScript """", FirstScriptDir)
 		if (ErrorLevel = 2)
-		{	FileRead tmpErrorData,%ilibfile%E
-			FileDelete %ilibfile%*
-			Util_Error("Error: The script contains syntax errors.", 0x11,tmpErrorData)
+		{	Util_Error("Error: The script contains syntax errors.", 0x11,tmpErrorData)
 		}
 		if (ErrLev := ErrorLevel)       ; Unexpected error has occurred
-		{	FileDelete %ilibfile%*
-			Util_Error("Error: Call to """ AhkPath """ has failed.`n(%comspec%="
+		{	Util_Error("Error: Call to """ AhkPath """ has failed.`n(%comspec%="
 			.  ComSpec ")`nError code is "ErrLev, 0x51)
 		}
-		IfExist, %ilibfile%
-		{	FileGetSize wk, %ilibfile%
-			if wk > 3
-			{	if SubStr(DerefIncludeVars.A_AhkVersion,1,1)=1
+		if StrLen(tmpErrorData) > 3
+			{	FileAppend, %tmpErrorData%, %ilibfile%
+				if SubStr(DerefIncludeVars.A_AhkVersion,1,1)=1
 				{ Loop 4                    ; v1 - Generate random label prefix
 					{ Random wk, 97, 122
 						ScriptText .= Chr(wk)   ; Prevent possible '#Warn Unreachable'
@@ -193,10 +185,9 @@ PreprocessScript(ByRef ScriptText, AhkScript, Directives, PriorLines
 				}
 				PreprocessScript(ScriptText, ilibfile, Directives
 				, PriorLines, FileList, FirstScriptDir, Options)
-		}	}
-		If (ilibfile)
-			FileDelete, %ilibfile%*
-		StringTrimRight, ScriptText, ScriptText, 1 ; remove trailing newline
+				FileDelete, %ilibfile%*
+			}
+			StringTrimRight, ScriptText, ScriptText, 1 ; remove trailing newline
 	}
 
 	DerefIncludeVars.A_LineFile := oldLineFile

--- a/ScriptParser.ahk
+++ b/ScriptParser.ahk
@@ -171,8 +171,7 @@ PreprocessScript(ByRef ScriptText, AhkScript, Directives, PriorLines
 		{	Util_Error("Error: The script contains syntax errors.", 0x11,tmpErrorData)
 		}
 		if (ErrLev := ErrorLevel)       ; Unexpected error has occurred
-		{	Util_Error("Error: Call to """ AhkPath """ has failed.`n(%comspec%="
-			.  ComSpec ")`nError code is "ErrLev, 0x51)
+		{	Util_Error("Error: Call to """ AhkPath """ has failed.`nError code is " ErrLev, 0x51)
 		}
 		if StrLen(tmpErrorData) > 3
 			{	FileAppend, %tmpErrorData%, %ilibfile%

--- a/Update.ahk
+++ b/Update.ahk
@@ -168,17 +168,14 @@ IfNotExist `%Tgt`%Ahk2Exe.exe
 if txt`n	MsgBox 48, Ahk2Exe Updater, Failed to update:`%txt`%``n`%Mess`%
 else MsgBox 64, Ahk2Exe Updater, Update completed successfully. `%Mess`%
 wk=#NoTrayIcon``nDetectHiddenWindows on``nWinKill ahk_id `%A_ScriptHwnd`%``n
-wk=`%wk`%WinWaitClose ahk_id `%A_ScriptHwnd`%,,10``n
+wk=`%wk`%WinWaitClose ahk_id `%A_ScriptHwnd`%,,10``nFileRemoveDir `%Src`%,1
 FileAppend `%wk`%, `%Src`%\Script2.ahk
 If FileExist(wk := Tgt "Ahk2Exe.exe")
 {	ToolTip Ahk2Exe Updater``nRestarting Ahk2Exe...
 	if (Store)`n  Run "`%wk`%" /restart `%Par`%, A_WorkingDir
 	else       RunAsUser(wk,  "/Restart " Par,   A_WorkingDir)
 }
-if !(Store)
-{	txt = "`%Src`%\A\Ahk2Exe.exe" /Script "`%Src`%\Script2.ahk" &  
-	RunWait "%ComSpec%" /c "`%txt`% rmdir /s /q "`%Src`%"",, Hide
-} else FileRemoveDir `%Src`%,1
+Run "`%Tgt`%Ahk2Exe.exe" /Script "`%Src`%\Script2.ahk"
 
 RunAsUser(target, args:="", workdir:="")
 {	try ShellRun(target, args, workdir)
@@ -240,6 +237,53 @@ UpdDirRem()
 
 HelpU(a)
 {	Run "https://www.autohotkey.com/boards/viewtopic.php?f=6&t=65095"
+}
+
+RunCMD(CmdLine, WorkingDir:="", Codepage:="CP0", Fn:="RunCMD_Output", Slow:=1) { ; RunCMD v0.97
+    Local         ; RunCMD v0.97 by SKAN on D34E/D67E @ autohotkey.com/boards/viewtopic.php?t=74647
+    Global G_RunCMD ; Based on StdOutToVar.ahk by Sean @ autohotkey.com/board/topic/15455-stdouttovar
+
+      Slow := !! Slow
+    , Fn := IsFunc(Fn) ? Func(Fn) : 0
+    , DllCall("CreatePipe", "PtrP",hPipeR:=0, "PtrP",hPipeW:=0, "Ptr",0, "Int",0)
+    , DllCall("SetHandleInformation", "Ptr",hPipeW, "Int",1, "Int",1)
+    , DllCall("SetNamedPipeHandleState","Ptr",hPipeR, "UIntP",PIPE_NOWAIT:=1, "Ptr",0, "Ptr",0)
+
+    , P8 := (A_PtrSize=8)
+    , VarSetCapacity(SI, P8 ? 104 : 68, 0)                          ; STARTUPINFO structure
+    , NumPut(P8 ? 104 : 68, SI)                                     ; size of STARTUPINFO
+    , NumPut(STARTF_USESTDHANDLES:=0x100, SI, P8 ? 60 : 44,"UInt")  ; dwFlags
+    , NumPut(hPipeW, SI, P8 ? 88 : 60)                              ; hStdOutput
+    , NumPut(hPipeW, SI, P8 ? 96 : 64)                              ; hStdError
+    , VarSetCapacity(PI, P8 ? 24 : 16)                              ; PROCESS_INFORMATION structure
+
+      If not DllCall("CreateProcess", "Ptr",0, "Str",CmdLine, "Ptr",0, "Int",0, "Int",True
+                    ,"Int",0x08000000 | DllCall("GetPriorityClass", "Ptr",-1, "UInt"), "Int",0
+                    ,"Ptr",WorkingDir ? &WorkingDir : 0, "Ptr",&SI, "Ptr",&PI)
+         Return Format("{1:}", "", ErrorLevel := -1
+                       ,DllCall("CloseHandle", "Ptr",hPipeW), DllCall("CloseHandle", "Ptr",hPipeR))
+
+      DllCall("CloseHandle", "Ptr",hPipeW)
+    , G_RunCMD := { "PID": NumGet(PI, P8? 16 : 8, "UInt") }
+    , File := FileOpen(hPipeR, "h", Codepage)
+
+    , LineNum := 1,  sOutput := ""
+      While  ( G_RunCMD.PID | DllCall("Sleep", "Int",Slow) )
+        and  DllCall("PeekNamedPipe", "Ptr",hPipeR, "Ptr",0, "Int",0, "Ptr",0, "Ptr",0, "Ptr",0)
+             While G_RunCMD.PID and StrLen(Line := File.ReadLine())
+                   sOutput .= Fn ? Fn.Call(Line, LineNum++) : Line
+
+    G_RunCMD.PID := 0
+    , hProcess := NumGet(PI, 0)
+    , hThread  := NumGet(PI, A_PtrSize)
+
+    , DllCall("GetExitCodeProcess", "Ptr",hProcess, "PtrP",ExitCode:=0)
+    , DllCall("CloseHandle", "Ptr",hProcess)
+    , DllCall("CloseHandle", "Ptr",hThread)
+    , DllCall("CloseHandle", "Ptr",hPipeR)
+    , ErrorLevel := ExitCode
+
+    Return sOutput
 }
 
 UpdGuiClose:


### PR DESCRIPTION
This pull request replaces all uses of `RunWait %ComSpec%` with RunCMD function (author: AHK forums user SKAN). The reasoning is as follows:
1) Not relying on ComSpec makes Ahk2Exe usable on more setups than previously. Namely it would allow compiling scripts even if cmd.exe usage is blocked by company policy or when running Windows in S-mode. The benefit of this is very modest because it's likely that if cmd.exe is blocked then the compiled exe is blocked as well, but there might be situations where only cmd.exe is blacklisted.
2) It seemingly has no downsides compared to ComSpec. Internally it uses CreateProcess like Run/RunWait do, but additionally creates a named pipe to access StdOut of the ran program. This means that it can read the output and ExitCode of ran scripts without relying on cmd.exe or writing to a file. 
3) There is possibility for a modest performance increase due to fewer file read-writes. Unfortunately ScriptParser.ahk still needed writing `tmpErrorData` to file `ilibfile` because `PreprocessScript` was dependent on the second argument being a file, but this might be changed in the future?

This pull request may be modified in any way deemed necessary.

